### PR TITLE
Add ability to specify a private pypi repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Setup Python Action
+
+- Sets up the python environment using actions/setup-python@v3
+- Installs poetry
+- Adds a private pypi repository (optional)
+- Installs all the packages using poetry
+
+## Inputs
+- python-version: `[required]`
+  - The python version to be used
+- url: `[optional]`
+    - The url of a private pypi repository that should be configured in poetry
+- user: `[optional]`
+    - The username to be used to connect to the private pypi repository
+- password: `[optional]`
+    - The password to be used to connect to the private pypi repository

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,15 @@ inputs:
   python-version:
     description: 'Python version to be used'
     required: true
+  url:
+    description: 'The url of the pypi repository'
+    required: false
+  user:
+    description: 'The username to be used to connect to the pypi repository'
+    required: false
+  password:
+    description: 'The password to be used to connect to the pypi repository'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -17,6 +26,13 @@ runs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install poetry
+
+    - name: Configure remote in poetry
+      if: ${{ inputs.url != '' }}
+      shell: bash
+      run: |
+        poetry config repositories.my-remote ${{ inputs.url }}
+        poetry config http-basic.my-remote ${{ inputs.user }} ${{ inputs.password }}
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
Allows poetry to install private packages
Limitation: Only 1 private repository is allowed